### PR TITLE
blogのスタイルにimgの幅設定を追加

### DIFF
--- a/pages/blog/_date/_slug/index.vue
+++ b/pages/blog/_date/_slug/index.vue
@@ -133,6 +133,10 @@ export default {
       height: auto;
       text-align: left;
 
+      /deep/ img {
+        width: 100%;
+      }
+
       @media (max-width: 600px) {
         line-height: normal;
         /deep/ h1 {


### PR DESCRIPTION
## 関連するIssue番号

close #94 

## 変更内容

imgがページの幅に統一されて表示されるようになります。

## 変更理由

imgがレイアウトが崩れることがあったため。

## 関連するページ

`/blog以下の記事`

## スクリーンショット

![image](https://user-images.githubusercontent.com/38032069/122158389-8c155280-cea7-11eb-924d-cd0b216e35cb.png)

大きい画像のものでもページ幅に合うようにしました。